### PR TITLE
Issue #67 Use Bootstrap styling instead of hard-coded style in Toggle Sidebar Button

### DIFF
--- a/10 Sidebar/package.json
+++ b/10 Sidebar/package.json
@@ -11,13 +11,13 @@
   "license": "MIT",
   "dependencies": {
     "bootstrap": "~3.3.7",
-    "react": "~15.6.1",
-    "react-dom": "~15.6.1"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "devDependencies": {
     "awesome-typescript-loader": "^3.2.3",
-    "@types/react": "~16.0.5",
-    "@types/react-dom": "~15.5.4",
+    "@types/react": "^16.0.18",
+    "@types/react-dom": "^16.0.2",
     "css-loader": "~0.28.7",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "~0.11.2",

--- a/10 Sidebar/readme.md
+++ b/10 Sidebar/readme.md
@@ -203,15 +203,11 @@ export class App extends React.Component<{}, State> {
     this.setState({userName: event.target.value});
   }
 
-+   toggleSidebarVisibility() {
++   toggleSidebarVisibility () => {
 +     const newVisibleState = !this.state.isSidebarVisible;
 +
 +     this.setState({isSidebarVisible: newVisibleState} as State);
 +   }
-
-+   ButtonStyle = {
-+      marginLeft: '450px'
-+   };
 
 
   public render() {
@@ -221,12 +217,13 @@ export class App extends React.Component<{}, State> {
 +        <SidebarComponent isVisible={this.state.isSidebarVisible}/>
         <HelloComponent userName={this.state.userName} />
         <NameEditComponent userName={this.state.userName} onChange={this.setUsernameState.bind(this)} />
-+        <input type="submit"
-+          value="Toggle Sidear"
-+          className="btn btn-default"
-+          style={this.ButtonStyle}
-+          onClick={this.toggleSidebarVisibility.bind(this)}
-+          />
++       <div className="pull-right">
++         <button
++           className="btn btn-default"
++           onClick={this.toggleSidebarVisibility}>
++           Toggle Sidebar
++         </button>
++       </div>
         
       </div>
     );

--- a/10 Sidebar/src/app.tsx
+++ b/10 Sidebar/src/app.tsx
@@ -23,15 +23,11 @@ export class App extends React.Component<Props, State> {
     this.setState({userName: event.target.value} as State);
   }
 
-  toggleSidebarVisibility() {
+  toggleSidebarVisibility = () => {
     const newVisibleState = !this.state.isSidebarVisible;
 
     this.setState({isSidebarVisible: newVisibleState} as State);
   }
-
-  ButtonStyle = {
-     marginLeft: '450px'
-   };
 
   public render() {
     return (
@@ -41,12 +37,13 @@ export class App extends React.Component<Props, State> {
         </SidebarComponent>
         <HelloComponent userName={this.state.userName} />
         <NameEditComponent userName={this.state.userName} onChange={this.setUsernameState.bind(this)} />
-        <input type="submit"
-          value="Toggle Sidear"
-          className="btn btn-default"
-          style={this.ButtonStyle}
-          onClick={this.toggleSidebarVisibility.bind(this)}
-          />
+        <div className="pull-right">
+          <button
+            className="btn btn-default"
+            onClick={this.toggleSidebarVisibility}>
+            Toggle Sidebar
+        </button>
+        </div>
       </div>
     );
   }

--- a/10 Sidebar/src/app.tsx
+++ b/10 Sidebar/src/app.tsx
@@ -42,7 +42,7 @@ export class App extends React.Component<Props, State> {
             className="btn btn-default"
             onClick={this.toggleSidebarVisibility}>
             Toggle Sidebar
-        </button>
+          </button>
         </div>
       </div>
     );


### PR DESCRIPTION
Implemented changes described in the issue:
- Use pull-right instead of custom style rule
- Change input element of type button to button element for greater clarity
- Update readme accordingly

Additionally, react, react-dom and the corresponding types dependencies have been updated to newer versions, as linting errors were being reported even without making any changes whatsoever to the source code.