### PR TITLE
fix: no allow to set name to empty string

### DIFF
--- a/07_Enable/readme.md
+++ b/07_Enable/readme.md
@@ -110,7 +110,8 @@ _[./src/app.tsx](./src/app.tsx)_
         <HelloComponent userName={this.state.userName} />
         <NameEditComponent
 +        disable={!this.state.userName 
-+        || this.state.userName === this.state.editingUserName}
++        || this.state.userName === this.state.editingUserName
++        || this.sate.editingUserName === '' }
           userName={this.state.userName}
           editingUserName={this.state.editingUserName}
           onEditingNameUpdated={this.updateEditingName}


### PR DESCRIPTION
Add disabled state when `state.editingName === ''`, before the input get disabled for ever when `state.userName` was set to empty string.